### PR TITLE
Update getStepCount().md

### DIFF
--- a/docs/getStepCount().md
+++ b/docs/getStepCount().md
@@ -3,8 +3,7 @@ Get the aggregated total steps for a specific day (starting and ending at midnig
 An optional options object may be provided containing `date` field representing the selected day. If `date` is not set or an options object is not provided then the current day will be used.
 ```javascript
 let options = {
-    startDate: new Date(2020, 1, 1).toISOString(), // required
-    endDate: new Date().toISOString(), // optional; default now
+    date: new Date(2020, 1, 1).toISOString(), // optional
 };
 ```
 
@@ -19,6 +18,8 @@ AppleHealthKit.getStepCount(options: Object, (err: Object, results: Object) => {
 
 ```javascript
 {
-	value: 213,
+        "endDate": "2020-01-01T12:09:42.335+0800", 
+        "startDate": "2020-01-01T08:14:45.467+0800"
+	"value": 213,
 }
 ```


### PR DESCRIPTION
Just updating the documentation as the previous changes was incorrect.

As shown in the Objective-C implementation [here](https://github.com/lucaspbordignon/rn-apple-healthkit/blob/master/RCTAppleHealthKit/RCTAppleHealthKit+Methods_Fitness.m#L20):
```objective-c
- (void)fitness_getStepCountOnDay:(NSDictionary *)input callback:(RCTResponseSenderBlock)callback
{
    NSDate *date = [RCTAppleHealthKit dateFromOptions:input key:@"date" withDefault:[NSDate date]];

    if(date == nil) {
        callback(@[RCTMakeError(@"could not parse date from options.date", nil, nil)]);
        return;
    }

    HKQuantityType *stepCountType = [HKObjectType quantityTypeForIdentifier:HKQuantityTypeIdentifierStepCount];
    HKUnit *stepsUnit = [HKUnit countUnit];

    [self fetchSumOfSamplesOnDayForType:stepCountType
                                   unit:stepsUnit
                                    day:date
                             completion:^(double value, NSDate *startDate, NSDate *endDate, NSError *error) {
        if (!value) {
            callback(@[RCTJSErrorFromNSError(error)]);
            return;
        }

         NSDictionary *response = @{
                 @"value" : @(value),
                 @"startDate" : [RCTAppleHealthKit buildISO8601StringFromDate:startDate],
                 @"endDate" : [RCTAppleHealthKit buildISO8601StringFromDate:endDate],
         };

        callback(@[[NSNull null], response]);
    }];
}
```

`getStepCount` is accepting `date` as optional and returning `startDate`, `endDate` and `value`.

### Changes:

- Replace `startDate` and `endDate` in `options` with `date` and commented it with `optional`.
- Add `startDate` and `endDate` to the return result